### PR TITLE
add service worker registration to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,12 @@
     <meta name="theme-color" content="#270e30">
     <title>CryptoVue</title>
 
+    <noscript>
+      <h4 style="font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica;">
+        Sorry, JavaScript needs to be enabled in order to run this application :(
+      </h4>
+    </noscript>
+
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -37,7 +43,18 @@
 
       ga('create', 'UA-90093928-4', 'auto');
       ga('send', 'pageview');
+    </script>
 
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/service-worker.js').then(registration => {
+            console.log('service worker registration was successful')
+          }, err => {
+            console.log('service worker registration failed')
+          });
+        });
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
You're using Google's [`sw-precache`](https://github.com/GoogleChrome/sw-precache) library to generate a service worker file on the fly, which is awesome 🙌 🎉 

Although the service worker gets generated right to the deployment folder, the app doesn't try looking for the file and register it. This snippet will check if the browser allows service worker usage and if so, register it so the app can work offline.

Also added a `noscript` tag to pop a message if the user has JS disabled - a better solution for this would be relying on server side rendering some of the content so at least we can have graceful degradation for users without JS (but that's a discussion for a different time - need to outweigh the effort/benefits of course :)
